### PR TITLE
Support for composable/extensible test context

### DIFF
--- a/Source/RoslynNUnitLight/AnalysisTestFixture.cs
+++ b/Source/RoslynNUnitLight/AnalysisTestFixture.cs
@@ -60,7 +60,7 @@ namespace RoslynNUnitLight
                 cancellationToken: CancellationToken.None);
 
             ImmutableArray<Diagnostic> compilerDiagnostics = compilation.GetDiagnostics(CancellationToken.None);
-            AssertCompilerDiagnostics(compilerDiagnostics);
+            ValidateCompilerDiagnostics(compilerDiagnostics);
 
             SyntaxTree tree = document.GetSyntaxTreeAsync().Result;
 
@@ -77,9 +77,9 @@ namespace RoslynNUnitLight
             return builder.ToImmutable();
         }
 
-        protected virtual void AssertCompilerDiagnostics(ImmutableArray<Diagnostic> compilerDiagnostics)
+        protected virtual void ValidateCompilerDiagnostics(ImmutableArray<Diagnostic> compilerDiagnostics)
         {
-            var hasErrors = compilerDiagnostics.Any(d => d.Severity == DiagnosticSeverity.Error);
+            bool hasErrors = compilerDiagnostics.Any(d => d.Severity == DiagnosticSeverity.Error);
             Assert.That(hasErrors, Is.False);
         }
 

--- a/Source/RoslynNUnitLight/AnalysisTestFixture.cs
+++ b/Source/RoslynNUnitLight/AnalysisTestFixture.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+using NUnit.Framework;
+
+namespace RoslynNUnitLight
+{
+    public abstract class AnalysisTestFixture
+    {
+        protected abstract string DiagnosticId { get; }
+
+        protected abstract DiagnosticAnalyzer CreateAnalyzer();
+
+        protected abstract CodeFixProvider CreateFixProvider();
+
+        public void AssertDiagnostics(AnalyzerTestContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            RunDiagnostics(context);
+        }
+
+        private ImmutableArray<Diagnostic> RunDiagnostics(AnalyzerTestContext context)
+        {
+            DocumentWithSpans documentWithSpans = TestHelpers2.GetDocumentAndSpansFromMarkup(context.MarkupCode,
+                context.LanguageName, context.References, context.FileName);
+
+            ImmutableArray<Diagnostic> diagnostics = GetDiagnosticsForDocument(documentWithSpans.Document);
+            IList<TextSpan> spans = documentWithSpans.TextSpans;
+            Assert.That(diagnostics.Length, Is.EqualTo(spans.Count));
+
+            for (int index = 0; index < diagnostics.Length; index++)
+            {
+                var diagnostic = diagnostics[index];
+                var span = spans[index];
+
+                Assert.That(diagnostic.Id, Is.EqualTo(DiagnosticId));
+                Assert.That(diagnostic.Location.IsInSource, Is.True);
+                Assert.That(diagnostic.Location.SourceSpan, Is.EqualTo(span));
+            }
+
+            return diagnostics;
+        }
+
+        private ImmutableArray<Diagnostic> GetDiagnosticsForDocument(Document document)
+        {
+            ImmutableArray<DiagnosticAnalyzer> analyzers = ImmutableArray.Create(CreateAnalyzer());
+            Compilation compilation = document.Project.GetCompilationAsync().Result;
+            CompilationWithAnalyzers compilationWithAnalyzers = compilation.WithAnalyzers(analyzers,
+                cancellationToken: CancellationToken.None);
+
+            ImmutableArray<Diagnostic> compilerDiagnostics = compilation.GetDiagnostics(CancellationToken.None);
+            AssertCompilerDiagnostics(compilerDiagnostics);
+
+            SyntaxTree tree = document.GetSyntaxTreeAsync().Result;
+
+            ImmutableArray<Diagnostic>.Builder builder = ImmutableArray.CreateBuilder<Diagnostic>();
+            foreach (Diagnostic analyzerDiagnostic in compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().Result)
+            {
+                Location location = analyzerDiagnostic.Location;
+                if (location.IsInSource && location.SourceTree == tree)
+                {
+                    builder.Add(analyzerDiagnostic);
+                }
+            }
+
+            return builder.ToImmutable();
+        }
+
+        protected virtual void AssertCompilerDiagnostics(ImmutableArray<Diagnostic> compilerDiagnostics)
+        {
+            var hasErrors = compilerDiagnostics.Any(d => d.Severity == DiagnosticSeverity.Error);
+            Assert.That(hasErrors, Is.False);
+        }
+
+        public void AssertDiagnosticsWithCodeFixes(FixProviderTestContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            ImmutableArray<Diagnostic> diagnostics = RunDiagnostics(context.AnalyzerTestContext);
+
+            IList<string> expectedCode = TestHelpers2.RemoveMarkupFrom(context.Expected,
+                context.AnalyzerTestContext.LanguageName, context.ReformatExpected,
+                context.AnalyzerTestContext.References, context.AnalyzerTestContext.FileName);
+            context = context.WithExpected(expectedCode);
+
+            CodeFixProvider fixProvider = CreateFixProvider();
+            foreach (var diagnostic in diagnostics)
+            {
+                RunCodeFixes(context, diagnostic, fixProvider);
+            }
+        }
+
+        private void RunCodeFixes(FixProviderTestContext context, Diagnostic diagnostic, CodeFixProvider fixProvider)
+        {
+            for (int index = 0; index < context.Expected.Count; index++)
+            {
+                Document document =
+                    TestHelpers2.GetDocumentAndSpansFromMarkup(context.AnalyzerTestContext.MarkupCode,
+                        context.AnalyzerTestContext.LanguageName, context.AnalyzerTestContext.References,
+                        context.AnalyzerTestContext.FileName).Document;
+
+                ImmutableArray<CodeAction> codeFixes = GetCodeFixesForDiagnostic(diagnostic, document, fixProvider);
+                Assert.That(codeFixes.Length, Is.EqualTo(context.Expected.Count));
+
+                Verify.CodeAction(codeFixes[index], document, context.Expected[index]);
+            }
+        }
+
+        private ImmutableArray<CodeAction> GetCodeFixesForDiagnostic(Diagnostic diagnostic, Document document,
+            CodeFixProvider fixProvider)
+        {
+            ImmutableArray<CodeAction>.Builder builder = ImmutableArray.CreateBuilder<CodeAction>();
+            Action<CodeAction, ImmutableArray<Diagnostic>> registerCodeFix = (a, _) => builder.Add(a);
+
+            var context = new CodeFixContext(document, diagnostic, registerCodeFix, CancellationToken.None);
+            fixProvider.RegisterCodeFixesAsync(context).Wait();
+
+            return builder.ToImmutable();
+        }
+    }
+}

--- a/Source/RoslynNUnitLight/AnalyzerTestContext.cs
+++ b/Source/RoslynNUnitLight/AnalyzerTestContext.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+
+namespace RoslynNUnitLight
+{
+    public class AnalyzerTestContext
+    {
+        protected const string DefaultFileName = "TestDocument";
+
+        protected static readonly ImmutableList<MetadataReference> DefaultReferences =
+            ImmutableList.Create(MetadataReference.CreateFromAssembly(typeof (object).GetTypeInfo().Assembly),
+                MetadataReference.CreateFromAssembly(typeof (Enumerable).GetTypeInfo().Assembly));
+
+        public virtual string MarkupCode { get; }
+
+        public virtual string LanguageName { get; }
+
+        public virtual string FileName { get; }
+
+        public virtual ImmutableList<MetadataReference> References { get; }
+
+        protected AnalyzerTestContext(string markupCode, string languageName, string fileName,
+            ImmutableList<MetadataReference> references)
+        {
+            if (markupCode == null)
+            {
+                throw new ArgumentNullException(nameof(markupCode));
+            }
+            if (languageName == null)
+            {
+                throw new ArgumentNullException(nameof(languageName));
+            }
+
+            MarkupCode = markupCode;
+            LanguageName = languageName;
+            FileName = fileName;
+            References = references;
+        }
+
+        public AnalyzerTestContext(string markupCode, string languageName)
+            : this(markupCode, languageName, DefaultFileName, DefaultReferences)
+        {
+        }
+
+        public virtual AnalyzerTestContext WithFileName(string fileName)
+        {
+            return new AnalyzerTestContext(MarkupCode, LanguageName, fileName, References);
+        }
+
+        public virtual AnalyzerTestContext WithReferences(IEnumerable<MetadataReference> references)
+        {
+            ImmutableList<MetadataReference> referenceList = ImmutableList.CreateRange(references);
+            return new AnalyzerTestContext(MarkupCode, LanguageName, FileName, referenceList);
+        }
+    }
+}

--- a/Source/RoslynNUnitLight/AnalyzerTestFixture.cs
+++ b/Source/RoslynNUnitLight/AnalyzerTestFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
@@ -8,6 +9,7 @@ using NUnit.Framework;
 
 namespace RoslynNUnitLight
 {
+    [Obsolete("Derive from AnalysisTestFixture instead.")]
     public abstract class AnalyzerTestFixture : BaseTestFixture
     {
         protected abstract DiagnosticAnalyzer CreateAnalyzer();

--- a/Source/RoslynNUnitLight/CodeFixTestFixture.cs
+++ b/Source/RoslynNUnitLight/CodeFixTestFixture.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 
 namespace RoslynNUnitLight
 {
+    [Obsolete("Derive from AnalysisTestFixture instead.")]
     public abstract class CodeFixTestFixture : BaseTestFixture
     {
         protected abstract CodeFixProvider CreateProvider();

--- a/Source/RoslynNUnitLight/DocumentWithSpans.cs
+++ b/Source/RoslynNUnitLight/DocumentWithSpans.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace RoslynNUnitLight
+{
+    internal class DocumentWithSpans
+    {
+        public Document Document { get; }
+        public IList<TextSpan> TextSpans { get; }
+
+        public DocumentWithSpans(Document document, IList<TextSpan> textSpans)
+        {
+            if (document == null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+            if (textSpans == null)
+            {
+                throw new ArgumentNullException(nameof(textSpans));
+            }
+
+            Document = document;
+            TextSpans = textSpans;
+        }
+    }
+}

--- a/Source/RoslynNUnitLight/FixProviderTestContext.cs
+++ b/Source/RoslynNUnitLight/FixProviderTestContext.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace RoslynNUnitLight
+{
+    public class FixProviderTestContext
+    {
+        public virtual AnalyzerTestContext AnalyzerTestContext { get; }
+
+        public virtual ImmutableList<string> Expected { get; }
+
+        public virtual bool ReformatExpected { get; }
+
+        public FixProviderTestContext(AnalyzerTestContext analyzerTestContext, IEnumerable<string> expected,
+            bool reformatExpected = true)
+        {
+            if (analyzerTestContext == null)
+            {
+                throw new ArgumentNullException(nameof(analyzerTestContext));
+            }
+            if (expected == null)
+            {
+                throw new ArgumentNullException(nameof(expected));
+            }
+
+            AnalyzerTestContext = analyzerTestContext;
+            Expected = ImmutableList.CreateRange(expected);
+            ReformatExpected = reformatExpected;
+        }
+
+        public virtual FixProviderTestContext WithExpected(IEnumerable<string> expected)
+        {
+            return new FixProviderTestContext(AnalyzerTestContext, expected, ReformatExpected);
+        }
+    }
+}

--- a/Source/RoslynNUnitLight/RoslynNUnitLight.csproj
+++ b/Source/RoslynNUnitLight/RoslynNUnitLight.csproj
@@ -69,12 +69,17 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AnalysisTestFixture.cs" />
+    <Compile Include="AnalyzerTestContext.cs" />
     <Compile Include="AnalyzerTestFixture.cs" />
     <Compile Include="BaseTestFixture.cs" />
     <Compile Include="CodeFixTestFixture.cs" />
     <Compile Include="CodeRefactoringTestFixture.cs" />
+    <Compile Include="DocumentWithSpans.cs" />
+    <Compile Include="FixProviderTestContext.cs" />
     <Compile Include="TestHelpers.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestHelpers2.cs" />
     <Compile Include="Verify.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/RoslynNUnitLight/TestHelpers2.cs
+++ b/Source/RoslynNUnitLight/TestHelpers2.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Text;
+
+namespace RoslynNUnitLight
+{
+    internal class TestHelpers2
+    {
+        public static DocumentWithSpans GetDocumentAndSpansFromMarkup(string markupCode, string languageName,
+            ImmutableList<MetadataReference> references, string fileName)
+        {
+            string code;
+            IList<TextSpan> spans;
+            GetCodeAndSpansFromMarkup(markupCode, out code, out spans);
+
+            var document = GetDocument(code, languageName, references, fileName);
+            return new DocumentWithSpans(document, spans);
+        }
+
+        private static void GetCodeAndSpansFromMarkup(string markupCode, out string code, out IList<TextSpan> spans)
+        {
+            code = null;
+            spans = null;
+
+            var codeBuilder = new StringBuilder();
+            var textSpans = new List<TextSpan>();
+
+            int offset = 0;
+            var start = markupCode.IndexOf("[|", offset, StringComparison.Ordinal);
+            while (start != -1)
+            {
+                codeBuilder.Append(markupCode.Substring(offset, start - offset));
+
+                var end = markupCode.IndexOf("|]", start + 2, StringComparison.Ordinal);
+                if (end == -1)
+                {
+                    throw new Exception("Missing |] in source.");
+                }
+
+                codeBuilder.Append(markupCode.Substring(start + 2, end - start - 2));
+
+                int shift = textSpans.Count * 4;
+                textSpans.Add(TextSpan.FromBounds(start - shift, end - 2 - shift));
+
+                offset = end + 2;
+                start = markupCode.IndexOf("[|", offset, StringComparison.Ordinal);
+            }
+
+            var extra = markupCode.IndexOf("|]", offset, StringComparison.Ordinal);
+            if (extra != -1)
+            {
+                throw new Exception("Additional |] in source.");
+            }
+
+            codeBuilder.Append(markupCode.Substring(offset));
+
+            spans = textSpans;
+            code = codeBuilder.ToString();
+        }
+
+        public static Document GetDocument(string code, string languageName,
+            ImmutableList<MetadataReference> references, string fileName)
+        {
+            return new AdhocWorkspace()
+                .AddProject("TestProject", languageName)
+                    .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+                .AddMetadataReferences(references)
+                .AddDocument(fileName, code);
+        }
+        
+        public static IList<string> RemoveMarkupFrom(IList<string> expected, string language, bool reformat,
+            ImmutableList<MetadataReference> references, string fileName)
+        {
+            return expected.Select(text => 
+                RemoveMarkupFrom(text, language, reformat, references, fileName)).ToList();
+        }
+
+        private static string RemoveMarkupFrom(string expected, string language, bool reformat,
+            ImmutableList<MetadataReference> references, string fileName)
+        {
+            Document document =
+                GetDocumentAndSpansFromMarkup(expected, language, references, fileName).Document;
+            SyntaxNode syntaxRoot = document.GetSyntaxRootAsync().Result;
+
+            if (reformat)
+            {
+                SyntaxNode formattedSyntaxRoot = Formatter.Format(syntaxRoot, document.Project.Solution.Workspace);
+                return formattedSyntaxRoot.ToFullString();
+            }
+
+            return syntaxRoot.ToFullString();
+        }
+    }
+}

--- a/Source/RoslynNUnitLight/Verify.cs
+++ b/Source/RoslynNUnitLight/Verify.cs
@@ -20,7 +20,7 @@ namespace RoslynNUnitLight
 
             var newDocument = workspace.CurrentSolution.GetDocument(document.Id);
 
-            var sourceText = newDocument.GetTextAsync(CancellationToken.None).Result;
+            var sourceText = newDocument.GetTextAsync().Result;
             var text = sourceText.ToString();
 
             Assert.That(text, Is.EqualTo(expectedCode));


### PR DESCRIPTION
@DustinCampbell Here the pull request for my [comment](https://github.com/DustinCampbell/RoslynNUnitLight/issues/5#issuecomment-100218021) earlier. I left out the FluentAssertions parts. But all my other features are in here, because I'm using a quite different API. Putting all features in separate pull requests at this moment would case much duplication and painful merges later. Based on discussions around this pull request, I can update it and remove parts that may be added later in another form. At a later time, I'd like to add some extensibility points to plug a custom assertion framework. Consider this pull request an expression to the direction I'd like to take this.

A key difference is that testing a `CodeFixProvider` can only be done from the output of its associated analyzer. This makes it possible to transfer analyzer state through `Diagnostic.Properties`, along with its reported span(s) and automatically test-apply all suggested fixes. Personally, as an analyzer developer, I am more interested in testing a working combination of Analyzer + FixProvider, rather than unittesting scenarios for a standalone FixProvider.

So I have one base class, `AnalysisTestFixture`, from which unittests derive. To run a test, an immutable context is passed in. It has Withers to supply additional information, such as extra references, filename etc.

Lastly, I changed reporting of builtin compiler errors, which were discarded before. I found that valuable, as it revealed some broken tests I had written weeks ago. The assertion method is virtual, so can be overridden from unittest classes. Callback could also be moved into context, if desired.

As an example, I rewrote the template tests for a new Analyzer/FixProvider project to use my API:

``` C#
using Microsoft.CodeAnalysis;
using Microsoft.CodeAnalysis.CodeFixes;
using Microsoft.CodeAnalysis.Diagnostics;
using NUnit.Framework;
using RoslynNUnitLight;

namespace UppercaseClass.Test
{
    [TestFixture]
    internal class UppercaseClassNameUnitTest: AnalysisTestFixture
    {
        protected override string DiagnosticId => UppercaseClassAnalyzer.DiagnosticId;

        [Test]
        public void TestMethod1()
        {
            // No diagnostics expected to show up

            const string source = @"";

            var context = new AnalyzerTestContext(source, LanguageNames.CSharp);
            AssertDiagnostics(context);
        }

        [Test]
        public void TestMethod2()
        {
            // Diagnostic and CodeFix both triggered and checked for

            const string source = @"
    using System;

    namespace ConsoleApplication1
    {
        class [|SomeTypeName|]
        {   
        }
    }";

            string expected = source.Replace("[|SomeTypeName|]", "SOMETYPENAME");

            var analyzerContext = new AnalyzerTestContext(source, LanguageNames.CSharp);
            var fixContext = new FixProviderTestContext(analyzerContext, new[] { expected }, reformatExpected: false);
            AssertDiagnosticsWithCodeFixes(fixContext);
        }

        protected override DiagnosticAnalyzer CreateAnalyzer()
        {
            return new UppercaseClassAnalyzer();
        }

        protected override CodeFixProvider CreateFixProvider()
        {
            return new UppercaseClassCodeFixProvider();
        }
    }
}
```
